### PR TITLE
Make null icons use the error/checkers sprite

### DIFF
--- a/src/parser/dmm_instance.js
+++ b/src/parser/dmm_instance.js
@@ -125,8 +125,8 @@ class Instance {
 				color = [1,1,1];
 			}
 			this.cached_appearance = new Appearance({
-				icon: icon ? icon.file : null,
-				icon_state: this.get_var("icon_state"),
+				icon: icon ? icon.file : '_fastdmm_interface.dmi',
+				icon_state: icon ? this.get_var("icon_state") : null,
 				dir: this.get_var("dir") & 0xF,
 				color,
 				layer: +this.get_var("layer") || 0,

--- a/src/rendering/renderer.js
+++ b/src/rendering/renderer.js
@@ -238,7 +238,10 @@ function draw_appearance(transform, z, obj, bounds_info = undefined, pointerid =
 	}
 
 	let icon = obj.icon;
-	if(!icon) return;
+	if(!icon) {
+		icon ='_fastdmm_interface.dmi';
+		icon_state = "";
+	}
 	let icon_meta;
 	let icon_state = obj.icon_state;
 	if(icon == "white") {


### PR DESCRIPTION
In the case where an icon has no `icon` set, it will use the checkers sprite.
This is important for mapmerge markers and MDB-DMM markers on most maps, them being invisible when rendered on the map makes it hard to identify them.

![image](https://user-images.githubusercontent.com/10366817/198998220-a464a32f-f1eb-48ec-bc7e-46640d32cb9e.png)

Previously all the /obj were invisible.